### PR TITLE
Add complete command

### DIFF
--- a/src/Todo.CLI/Commands/CompleteCommand.cs
+++ b/src/Todo.CLI/Commands/CompleteCommand.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.CommandLine;
+using Todo.CLI.Handlers;
+using Todo.Core;
+using Todo.Core.Model;
+
+namespace Todo.CLI.Commands
+{
+    public class CompleteCommand : Command
+    {
+        public CompleteCommand(IServiceProvider serviceProvider) : base("complete")
+        {
+            Description = "Completes a to do item.";
+
+            AddOption(GetItemOption());
+
+            Handler = CompleteCommandHandler.Create(serviceProvider);
+        }
+
+        private Option GetItemOption()
+        {
+            return new Option(new string[] { "id", "item-id" }, "The unique identifier of the todo item to complete.");
+        }
+    }
+}

--- a/src/Todo.CLI/Commands/TodoCommand.cs
+++ b/src/Todo.CLI/Commands/TodoCommand.cs
@@ -23,6 +23,7 @@ namespace Todo.CLI.Commands
             // Add subcommands
             AddCommand(new AddCommand(serviceProvider));
             AddCommand(new ListCommand(serviceProvider));
+            AddCommand(new CompleteCommand(serviceProvider));
         }
 
         private Option GetVersionOption()

--- a/src/Todo.CLI/Handlers/CompleteCommandHandler.cs
+++ b/src/Todo.CLI/Handlers/CompleteCommandHandler.cs
@@ -1,0 +1,39 @@
+﻿using InquirerCS;
+using System;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using Todo.Core;
+using Todo.Core.Model;
+
+namespace Todo.CLI.Handlers
+{
+    public class CompleteCommandHandler
+    {
+        public static ICommandHandler Create(IServiceProvider serviceProvider)
+        {
+            return CommandHandler.Create<string>(async (itemId) =>
+            {
+                var todoItemRepository = (ITodoItemRepository)serviceProvider.GetService(typeof(ITodoItemRepository));
+                if (!string.IsNullOrEmpty(itemId))
+                {
+                    await todoItemRepository.CompleteAsync(new TodoItem() { Id = itemId });
+                }
+                else
+                {
+                    // Retrieve items that are not completed
+                    var items = await todoItemRepository.ListAsync(listAll: false);
+
+                    // Ask user which item to complete
+                    var selectedItem = Question
+                        .List("Which item would you like to complete?", items)
+                        .Prompt();
+
+                    await todoItemRepository.CompleteAsync(selectedItem);
+                }
+            });
+        }
+    }
+}

--- a/src/Todo.CLI/Todo.CLI.csproj
+++ b/src/Todo.CLI/Todo.CLI.csproj
@@ -23,6 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Inquirer.cs" Version="3.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />

--- a/src/Todo.Core/Model/TodoItem.cs
+++ b/src/Todo.Core/Model/TodoItem.cs
@@ -6,6 +6,7 @@ namespace Todo.Core.Model
 {
     public class TodoItem
     {
+        public string Id { get; set; }
         public string Subject { get; set; }
     }
 }

--- a/src/Todo.Core/Model/TodoItem.cs
+++ b/src/Todo.Core/Model/TodoItem.cs
@@ -8,5 +8,6 @@ namespace Todo.Core.Model
     {
         public string Id { get; set; }
         public string Subject { get; set; }
+        public override string ToString() => Subject;
     }
 }

--- a/src/Todo.Core/Repository/ITodoItemRepository.cs
+++ b/src/Todo.Core/Repository/ITodoItemRepository.cs
@@ -11,5 +11,6 @@ namespace Todo.Core
     {
         Task AddAsync(TodoItem item);
         Task<IEnumerable<TodoItem>> ListAsync(bool listAll);
+        Task CompleteAsync(TodoItem item);
     }
 }

--- a/src/Todo.Core/Repository/TodoItemRepository.cs
+++ b/src/Todo.Core/Repository/TodoItemRepository.cs
@@ -36,6 +36,7 @@ namespace Todo.Core.Repository
             var tasks = await request.GetAsync();
             return tasks.Select(task => new TodoItem() 
             { 
+                Id = task.Id,
                 Subject = task.Subject
             });
         }

--- a/src/Todo.Core/Repository/TodoItemRepository.cs
+++ b/src/Todo.Core/Repository/TodoItemRepository.cs
@@ -25,6 +25,14 @@ namespace Todo.Core.Repository
             });
         }
 
+        public async Task CompleteAsync(TodoItem item)
+        {
+            var graphServiceClient = new GraphServiceClient(AuthenticationProvider);
+            var requestUrl = graphServiceClient.Me.Outlook.Tasks.AppendSegmentToRequestUrl($"{item.Id}/complete");
+            var builder = new OutlookTaskCompleteRequestBuilder(requestUrl, graphServiceClient);
+            await builder.Request().PostAsync();
+        }
+
         public async Task<IEnumerable<TodoItem>> ListAsync(bool listAll)
         {
             var graphServiceClient = new GraphServiceClient(AuthenticationProvider);

--- a/src/Todo.Core/Todo.Core.csproj
+++ b/src/Todo.Core/Todo.Core.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Graph.Auth" Version="1.0.0-preview.1" />
+    <PackageReference Include="Microsoft.Graph.Auth" Version="1.0.0-preview.2" />
     <PackageReference Include="Microsoft.Graph.Beta" Version="0.8.0-preview" />
   </ItemGroup>
 


### PR DESCRIPTION
Adds a complete command that allows completion of to-do items.

The command prompts the user to select an item unless the ID is specified by the `--item-id` option. The prompt uses [Inquirer.cs](https://github.com/agolaszewski/Inquirer.cs), which is not yet .NET Core compatible, but will be once agolaszewski/Inquirer.cs#59 is resolved.

Completes #7 (no pun intended 😅)