### PR TITLE
Get all tasks including further pages, and optionally remove all found tasks

### DIFF
--- a/src/Todo.CLI/Commands/RemoveCommand.cs
+++ b/src/Todo.CLI/Commands/RemoveCommand.cs
@@ -7,11 +7,13 @@ namespace Todo.CLI.Commands;
 public class RemoveCommand : Command
 {
     private static readonly Option<string> ListOpt = new(["--list", "-l"], "The name of the list to remove the item from.");
-    private static readonly Option<DateTime?> OlderThanOpt = new(new[] { "--older-than" }, "Only items completed before this date.");
-    public RemoveCommand(IServiceProvider serviceProvider) : base("remove", "Deletes a to do item.")
+    private static readonly Option<DateTime?> OlderThanOpt = new(["--older-than"], "Only items completed before this date.");
+    private static readonly Option<bool> AllOpt = new(new[] { "--all", "-a" }, "Remove all items fitting the filter. You will be prompted before removal.");
+    public RemoveCommand(IServiceProvider serviceProvider) : base("remove", "Deletes to do items.")
     {
         Add(ListOpt);
         Add(OlderThanOpt);
-        this.SetHandler(RemoveCommandHandler.Create(serviceProvider), ListOpt, OlderThanOpt);
+        Add(AllOpt);
+        this.SetHandler(RemoveCommandHandler.Create(serviceProvider), ListOpt, OlderThanOpt, AllOpt);
     }
 }

--- a/src/Todo.CLI/Handlers/CompleteCommandHandler.cs
+++ b/src/Todo.CLI/Handlers/CompleteCommandHandler.cs
@@ -48,6 +48,7 @@ public class CompleteCommandHandler
 
                     var selectedItems = Question
                         .Checkbox(message, items)
+                        .Page(50)
                         .Prompt();
 
                     CompleteItems(todoItemRepository, selectedItems);

--- a/src/Todo.CLI/Handlers/RemoveCommandHandler.cs
+++ b/src/Todo.CLI/Handlers/RemoveCommandHandler.cs
@@ -59,6 +59,7 @@ public class RemoveCommandHandler
         {
             var selectedItems = Question
                 .Checkbox(message, items)
+                .Page(50)
                 .Prompt();
 
             await DeleteItems(todoItemRepository, selectedItems);


### PR DESCRIPTION
Not sure if this is something you want for this tool, it was my current use case though so I thought why not send it upstream. I had a shopping list with almost 1k items that just keeps growing so I needed something to automatically clean that up for me. This let me automatically remove everything older than a certain date, since I often buy the same thing again so I can just go through the last few completed items and reopen them.