### PR TITLE
Add `--due-date` support for todo items

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,75 @@ The application will automatically prompt you to sign in with your Microsoft acc
 # Run using dotnet run
 dotnet run -p .\Todo.CLI -- --help
 
-# Run from build output (?)
-.\Todo.CLI\bin\Debug\netcoreapp3.0\todo --help
+# Run from build output
+.\src\publish\todo.exe --help
+```
+
+### Publish (self-contained .exe)
+
+```
+# Windows x64
+dotnet publish src\Todo.CLI -c Release -r win-x64 -o .\src\publish
+
+# macOS (Intel)
+dotnet publish src\Todo.CLI -c Release -r osx-x64 -o .\src\publish
+
+# macOS (Apple Silicon)
+dotnet publish src\Todo.CLI -c Release -r osx-arm64 -o .\src\publish
+
+# Linux x64
+dotnet publish src\Todo.CLI -c Release -r linux-x64 -o .\src\publish
+```
+
+## Usage
+
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| `todo add item <subject>` | Add a new to-do item |
+| `todo add list <name>` | Add a new to-do list |
+| `todo list [options]` | List items |
+| `todo complete <id>` | Mark an item as completed |
+| `todo remove <id>` | Remove an item |
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--list <name>` | Target a specific list |
+| `--star` | Mark the item as important |
+| `--due-date <date>` | Set a due date (`yyyy-MM-dd` or `MM-dd`) |
+
+### Examples
+
+```
+# Add an item with a due date
+todo add item "Buy groceries" --due-date 2026-05-20
+
+# Add an item with MM-dd format (current year is used)
+todo add item "Doctor appointment" --due-date 06-15
+
+# Add a starred item to a specific list
+todo add item "Important report" --star --list Work
+
+# List all tasks
+todo list
+
+# Mark a task as completed
+todo complete <task-id>
+
+# Remove a task
+todo remove <task-id>
+```
+
+### Output Example
+
+```
+Work (3):
+- Buy groceries - NotStarted (05-20)
+✓ Completed task - Completed (2026-05-10)
+- Important report - NotStarted
 ```
 
 ## Contributing

--- a/src/Todo.CLI.Tests/Commands/AddCommandTests.cs
+++ b/src/Todo.CLI.Tests/Commands/AddCommandTests.cs
@@ -46,7 +46,7 @@ public class AddCommandTests
         var handler = AddCommandHandler.Item.Create(_serviceProvider);
 
         // Act
-        var result = await handler(subject, listName, true);
+        var result = await handler(subject, listName, true, null);
 
         // Assert
         Assert.Equal(0, result);
@@ -104,7 +104,7 @@ public class AddCommandTests
         var handler = AddCommandHandler.Item.Create(_serviceProvider);
 
         // Act
-        var result = await handler(subject, listName, false);
+        var result = await handler(subject, listName, false, null);
 
         // Assert
         Assert.Equal(0, result);
@@ -128,7 +128,7 @@ public class AddCommandTests
         var handler = AddCommandHandler.Item.Create(_serviceProvider);
 
         // Act
-        var result = await handler(subject, listName, false);
+        var result = await handler(subject, listName, false, null);
 
         // Assert
         Assert.Equal(1, result);
@@ -151,7 +151,7 @@ public class AddCommandTests
         var handler = AddCommandHandler.Item.Create(_serviceProvider);
 
         // Act
-        var result = await handler(subject, null, false);
+        var result = await handler(subject, null, false, null);
 
         // Assert
         Assert.Equal(0, result);
@@ -174,7 +174,7 @@ public class AddCommandTests
         var handler = AddCommandHandler.Item.Create(_serviceProvider);
 
         // Act
-        var result = await handler(subject, null, false);
+        var result = await handler(subject, null, false, null);
 
         // Assert
         Assert.Equal(1, result);
@@ -191,7 +191,7 @@ public class AddCommandTests
         var handler = AddCommandHandler.Item.Create(_serviceProvider);
 
         // Act
-        var result = await handler(string.Empty, listName, false);
+        var result = await handler(string.Empty, listName, false, null);
 
         // Assert
         Assert.Equal(1, result);

--- a/src/Todo.CLI.Tests/Commands/AddCommandTests.cs
+++ b/src/Todo.CLI.Tests/Commands/AddCommandTests.cs
@@ -198,4 +198,160 @@ public class AddCommandTests
         _mockUserInteraction.Verify(ui => ui.ShowError("Subject is required to add an item."), Times.Once);
         _mockItemRepository.Verify(r => r.AddAsync(It.IsAny<TodoItem>()), Times.Never);
     }
+
+    [Fact]
+    public void ParseDueDate_Null_ReturnsNull()
+    {
+        // Act
+        var result = AddCommandHandler.ParseDueDate(null);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ParseDueDate_EmptyString_ReturnsNull()
+    {
+        // Act
+        var result = AddCommandHandler.ParseDueDate(string.Empty);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ParseDueDate_Whitespace_ReturnsNull()
+    {
+        // Act
+        var result = AddCommandHandler.ParseDueDate("   ");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ParseDueDate_ValidFullDate_ReturnsParsedDate()
+    {
+        // Arrange
+        var dueDateString = "2026-12-25";
+
+        // Act
+        var result = AddCommandHandler.ParseDueDate(dueDateString);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(2026, result!.Value.Year);
+        Assert.Equal(12, result.Value.Month);
+        Assert.Equal(25, result.Value.Day);
+    }
+
+    [Fact]
+    public void ParseDueDate_ValidShortDate_ReturnsCurrentYear()
+    {
+        // Arrange
+        var dueDateString = "12-25";
+        var currentYear = DateTime.Now.Year;
+
+        // Act
+        var result = AddCommandHandler.ParseDueDate(dueDateString);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(currentYear, result!.Value.Year);
+        Assert.Equal(12, result.Value.Month);
+        Assert.Equal(25, result.Value.Day);
+    }
+
+    [Fact]
+    public void ParseDueDate_InvalidFormat_ReturnsNull()
+    {
+        // Act
+        var result = AddCommandHandler.ParseDueDate("not-a-date");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ParseDueDate_WrongFormat_ReturnsNull()
+    {
+        // Act
+        var result = AddCommandHandler.ParseDueDate("25-12-2026");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task AddItem_WithValidDueDate_ShouldCreateItemWithDueDate()
+    {
+        // Arrange
+        var listName = "Test List";
+        var subject = "Test Item";
+        var listId = "list-123";
+        var list = new TodoList { Id = listId, Name = listName };
+        var dueDateString = "2026-12-25";
+
+        _mockListRepository.Setup(r => r.GetByNameAsync(listName))
+            .ReturnsAsync(list);
+
+        var handler = AddCommandHandler.Item.Create(_serviceProvider);
+
+        // Act
+        var result = await handler(subject, listName, false, dueDateString);
+
+        // Assert
+        Assert.Equal(0, result);
+        _mockItemRepository.Verify(r => r.AddAsync(It.Is<TodoItem>(i =>
+            i.Subject == subject &&
+            i.ListId == listId &&
+            i.DueDate != null &&
+            i.DueDate!.Value.Year == 2026 &&
+            i.DueDate.Value.Month == 12 &&
+            i.DueDate.Value.Day == 25)), Times.Once);
+    }
+
+    [Fact]
+    public async Task AddItem_WithInvalidDueDate_ShouldShowError()
+    {
+        // Arrange
+        var listName = "Test List";
+        var subject = "Test Item";
+        var dueDateString = "invalid-date";
+
+        var handler = AddCommandHandler.Item.Create(_serviceProvider);
+
+        // Act
+        var result = await handler(subject, listName, false, dueDateString);
+
+        // Assert
+        Assert.Equal(1, result);
+        _mockUserInteraction.Verify(ui => ui.ShowError("Invalid due date format. Use yyyy-MM-dd or MM-dd."), Times.Once);
+        _mockItemRepository.Verify(r => r.AddAsync(It.IsAny<TodoItem>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task AddItem_WithoutDueDate_ShouldCreateItemWithNullDueDate()
+    {
+        // Arrange
+        var listName = "Test List";
+        var subject = "Test Item";
+        var listId = "list-123";
+        var list = new TodoList { Id = listId, Name = listName };
+
+        _mockListRepository.Setup(r => r.GetByNameAsync(listName))
+            .ReturnsAsync(list);
+
+        var handler = AddCommandHandler.Item.Create(_serviceProvider);
+
+        // Act
+        var result = await handler(subject, listName, false, null);
+
+        // Assert
+        Assert.Equal(0, result);
+        _mockItemRepository.Verify(r => r.AddAsync(It.Is<TodoItem>(i =>
+            i.Subject == subject &&
+            i.ListId == listId &&
+            i.DueDate == null)), Times.Once);
+    }
 } 

--- a/src/Todo.CLI.Tests/UI/OutputFormatterTests.cs
+++ b/src/Todo.CLI.Tests/UI/OutputFormatterTests.cs
@@ -239,7 +239,7 @@ public class OutputFormatterTests
         var jsonDoc = JsonDocument.Parse(result);
         var root = jsonDoc.RootElement;
         Assert.True(root.TryGetProperty("DueDate", out var dueDateElement));
-        Assert.True(dueDateElement.IsNull());
+        Assert.Equal(JsonValueKind.Null, dueDateElement.ValueKind);
     }
 
     [Fact]

--- a/src/Todo.CLI.Tests/UI/OutputFormatterTests.cs
+++ b/src/Todo.CLI.Tests/UI/OutputFormatterTests.cs
@@ -304,7 +304,7 @@ public class OutputFormatterTests
     }
 
     [Fact]
-    public void InteractiveFormatter_FormatItem_WithDueDate_NoStatus_IncludesDateInOutput()
+    public void InteractiveFormatter_FormatItem_WithDueDate_NoStatus_ExcludesDateFromOutput()
     {
         // Arrange
         var formatter = new InteractiveOutputFormatter();
@@ -322,7 +322,7 @@ public class OutputFormatterTests
         var result = formatter.FormatItem(item, noStatus: true);
 
         // Assert
-        Assert.Contains("(08-10)", result);
+        Assert.DoesNotContain("(", result);
         Assert.Contains(item.Subject, result);
     }
 } 

--- a/src/Todo.CLI.Tests/UI/OutputFormatterTests.cs
+++ b/src/Todo.CLI.Tests/UI/OutputFormatterTests.cs
@@ -200,4 +200,129 @@ public class OutputFormatterTests
         Assert.Equal(_completedItem.Id, secondItem.GetProperty("Id").GetString());
         Assert.Equal(_completedItem.Subject, secondItem.GetProperty("Subject").GetString());
     }
+
+    [Fact]
+    public void JsonFormatter_FormatItem_WithDueDate_IncludesDueDateProperty()
+    {
+        // Arrange
+        var formatter = new JsonOutputFormatter();
+        var item = new TodoItem
+        {
+            Id = "3",
+            Subject = "Item with Due Date",
+            IsCompleted = false,
+            Status = "NotStarted",
+            ListId = "list-1",
+            DueDate = new DateTime(2026, 12, 25)
+        };
+
+        // Act
+        var result = formatter.FormatItem(item, noStatus: false);
+
+        // Assert
+        var jsonDoc = JsonDocument.Parse(result);
+        var root = jsonDoc.RootElement;
+        Assert.True(root.TryGetProperty("DueDate", out var dueDateElement));
+        Assert.Equal("2026-12-25", dueDateElement.GetString());
+    }
+
+    [Fact]
+    public void JsonFormatter_FormatItem_WithoutDueDate_DueDateIsNull()
+    {
+        // Arrange
+        var formatter = new JsonOutputFormatter();
+
+        // Act
+        var result = formatter.FormatItem(_incompleteItem, noStatus: false);
+
+        // Assert
+        var jsonDoc = JsonDocument.Parse(result);
+        var root = jsonDoc.RootElement;
+        Assert.True(root.TryGetProperty("DueDate", out var dueDateElement));
+        Assert.True(dueDateElement.IsNull());
+    }
+
+    [Fact]
+    public void JsonFormatter_FormatItem_WithDueDate_IncludesDateInDisplayText()
+    {
+        // Arrange
+        var formatter = new JsonOutputFormatter();
+        var item = new TodoItem
+        {
+            Id = "4",
+            Subject = "Display Item",
+            IsCompleted = false,
+            Status = "NotStarted",
+            ListId = "list-1",
+            DueDate = new DateTime(2026, 6, 15)
+        };
+
+        // Act
+        var result = formatter.FormatItem(item, noStatus: false);
+
+        // Assert
+        var jsonDoc = JsonDocument.Parse(result);
+        var displayText = jsonDoc.RootElement.GetProperty("DisplayText").GetString();
+        Assert.Contains("(06-15)", displayText);
+    }
+
+    [Fact]
+    public void InteractiveFormatter_FormatItem_WithDueDate_IncludesDateInOutput()
+    {
+        // Arrange
+        var formatter = new InteractiveOutputFormatter();
+        var item = new TodoItem
+        {
+            Id = "5",
+            Subject = "Interactive Item",
+            IsCompleted = false,
+            Status = "NotStarted",
+            ListId = "list-1",
+            DueDate = new DateTime(2026, 3, 20)
+        };
+
+        // Act
+        var result = formatter.FormatItem(item, noStatus: false);
+
+        // Assert
+        Assert.Contains("(03-20)", result);
+        Assert.Contains(item.Subject, result);
+    }
+
+    [Fact]
+    public void InteractiveFormatter_FormatItem_WithoutDueDate_ExcludesDateFromOutput()
+    {
+        // Arrange
+        var formatter = new InteractiveOutputFormatter();
+
+        // Act
+        var result = formatter.FormatItem(_incompleteItem, noStatus: false);
+
+        // Assert
+        Assert.DoesNotContain("(", result);
+        Assert.Contains(_incompleteItem.Subject, result);
+    }
+
+    [Fact]
+    public void InteractiveFormatter_FormatItem_WithDueDate_NoStatus_IncludesDateInOutput()
+    {
+        // Arrange
+        var formatter = new InteractiveOutputFormatter();
+        var item = new TodoItem
+        {
+            Id = "6",
+            Subject = "No Status Item",
+            IsCompleted = false,
+            Status = "NotStarted",
+            ListId = "list-1",
+            DueDate = new DateTime(2026, 8, 10)
+        };
+
+        // Act
+        var result = formatter.FormatItem(item, noStatus: true);
+
+        // Assert
+        Assert.Contains("(08-10)", result);
+        Assert.Contains(item.Subject, result);
+    }
 } 

--- a/src/Todo.CLI/Commands/AddCommand.cs
+++ b/src/Todo.CLI/Commands/AddCommand.cs
@@ -30,14 +30,16 @@ public class AddCommand : Command
         private static readonly Argument<string> SubjectArgument = new("subject", "The subject of the new to do item.");
         private static readonly Option<string> ListOption = new("--list", "The list to add the to do item to.");
         private static readonly Option<bool> StarOption = new("--star", "Stars (marks as important) the new to do item.");
+        private static readonly Option<string> DueDateOption = new("--due-date", "The due date (yyyy-MM-dd or MM-dd).");
 
         public AddItemCommand(IServiceProvider serviceProvider) : base("item", "Adds a new to do item.")
         {
             AddArgument(SubjectArgument);
             AddOption(ListOption);
             AddOption(StarOption);
+            AddOption(DueDateOption);
 
-            this.SetHandler(AddCommandHandler.Item.Create(serviceProvider), SubjectArgument, ListOption, StarOption);
+            this.SetHandler(AddCommandHandler.Item.Create(serviceProvider), SubjectArgument, ListOption, StarOption, DueDateOption);
         }
     }
 }

--- a/src/Todo.CLI/Handlers/AddCommandHandler.cs
+++ b/src/Todo.CLI/Handlers/AddCommandHandler.cs
@@ -36,7 +36,7 @@ public class AddCommandHandler
 
     public class Item
     {
-        public static Func<string, string, bool, Task<int>> Create(IServiceProvider serviceProvider)
+        public static Func<string, string, bool, string?, Task<int>> Create(IServiceProvider serviceProvider)
         {
             var todoListRepository = serviceProvider.GetRequiredService<ITodoListRepository>();
             var todoItemRepository = serviceProvider.GetRequiredService<ITodoItemRepository>();
@@ -44,6 +44,22 @@ public class AddCommandHandler
             var handler = new AddCommandHandler(todoListRepository, todoItemRepository, userInteraction);
             return handler.HandleItemAsync;
         }
+    }
+
+    private static DateTime? ParseDueDate(string? dueDateString)
+    {
+        if (string.IsNullOrWhiteSpace(dueDateString))
+            return null;
+
+        var currentYear = DateTime.Now.Year;
+
+        if (DateTime.TryParseExact(dueDateString, "yyyy-MM-dd", null, System.Globalization.DateTimeStyles.None, out var fullDate))
+            return fullDate;
+
+        if (DateTime.TryParseExact(dueDateString, "MM-dd", null, System.Globalization.DateTimeStyles.None, out var partialDate))
+            return new DateTime(currentYear, partialDate.Month, partialDate.Day);
+
+        return null;
     }
 
     private async Task<int> HandleListAsync(string name)
@@ -70,13 +86,20 @@ public class AddCommandHandler
         }
     }
 
-    private async Task<int> HandleItemAsync(string subject, string listName, bool star)
+    private async Task<int> HandleItemAsync(string subject, string listName, bool star, string? dueDateString)
     {
         try
         {
             if (string.IsNullOrEmpty(subject))
             {
                 _userInteraction.ShowError("Subject is required to add an item.");
+                return 1;
+            }
+
+            var dueDate = ParseDueDate(dueDateString);
+            if (dueDateString is not null && dueDate is null)
+            {
+                _userInteraction.ShowError($"Invalid due date format. Use yyyy-MM-dd or MM-dd.");
                 return 1;
             }
 
@@ -105,7 +128,8 @@ public class AddCommandHandler
             {
                 Subject = subject,
                 ListId = list.Id,
-                IsImportant = star
+                IsImportant = star,
+                DueDate = dueDate
             });
 
             _userInteraction.ShowSuccess($"Item '{subject}' added to list '{list.Name}' successfully.");

--- a/src/Todo.CLI/Handlers/AddCommandHandler.cs
+++ b/src/Todo.CLI/Handlers/AddCommandHandler.cs
@@ -46,7 +46,7 @@ public class AddCommandHandler
         }
     }
 
-    private static DateTime? ParseDueDate(string? dueDateString)
+    internal static DateTime? ParseDueDate(string? dueDateString)
     {
         if (string.IsNullOrWhiteSpace(dueDateString))
             return null;

--- a/src/Todo.CLI/Todo.CLI.csproj
+++ b/src/Todo.CLI/Todo.CLI.csproj
@@ -70,6 +70,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Todo.CLI.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/Todo.CLI/UI/JsonOutputFormatter.cs
+++ b/src/Todo.CLI/UI/JsonOutputFormatter.cs
@@ -66,6 +66,7 @@ public class JsonOutputFormatter : IOutputFormatter
             item.IsCompleted,
             item.Status,
             Completed = item.Completed?.ToString("yyyy-MM-dd"),
+            DueDate = item.DueDate?.ToString("yyyy-MM-dd"),
             item.ListId,
             DisplayText = noStatus ? item.Subject : item.ToString()
         };

--- a/src/Todo.Core/Model/TodoItem.cs
+++ b/src/Todo.Core/Model/TodoItem.cs
@@ -10,7 +10,8 @@ public class TodoItem
     public DateTime? Completed { get; set; }
     public DateTime? Created { get; set; }
     public string? ListId { get; set; }
+    public DateTime? DueDate { get; set; }
 
-    public override string ToString() => $"{Subject} - {Status} {(IsCompleted ? Completed?.ToString("yyyy-MM-dd") : string.Empty)}";
+    public override string ToString() => $"{Subject} - {Status} {(IsCompleted ? Completed?.ToString("yyyy-MM-dd") : string.Empty)}" + (DueDate.HasValue ? $" ({DueDate:MM-dd})" : string.Empty);
     public string ToString(bool noStatus) => noStatus ? Subject : ToString();
 }

--- a/src/Todo.Core/Repository/TodoItemRepository.cs
+++ b/src/Todo.Core/Repository/TodoItemRepository.cs
@@ -20,14 +20,25 @@ internal class TodoItemRepository : RepositoryBase, ITodoItemRepository
             throw new InvalidOperationException("item needs a ListId to identify the list to add it to.");
 
         var graphServiceClient = new GraphServiceClient(AuthenticationProvider);
-        _ = await graphServiceClient.Me.Todo.Lists[item.ListId].Tasks.PostAsync(new TodoTask
+        var newTask = new TodoTask
         {
             Title = item.Subject,
             Status = item.IsCompleted
                 ? TaskStatus.Completed
                 : TaskStatus.NotStarted,
             Importance = item.IsImportant ? Importance.High : Importance.Normal
-        });
+        };
+
+        if (item.DueDate.HasValue)
+        {
+            newTask.DueDateTime = new DateTimeTimeZone
+            {
+                DateTime = item.DueDate.Value.ToString("yyyy-MM-ddTHH:mm:ss"),
+                TimeZone = TimeZoneInfo.Local.Id
+            };
+        }
+
+        _ = await graphServiceClient.Me.Todo.Lists[item.ListId].Tasks.PostAsync(newTask);
     }
 
     public async Task CompleteAsync(TodoItem item)

--- a/src/Todo.Core/TodoDependencyInjectionExtensions.cs
+++ b/src/Todo.Core/TodoDependencyInjectionExtensions.cs
@@ -30,7 +30,8 @@ public static class TodoDependencyInjectionExtensions
             Status = task.Status?.ToString() ?? "Unknown",
             Completed = task.CompletedDateTime?.ToDateTime(),
             Created = task.CreatedDateTime?.DateTime,
-            ListId = listId
+            ListId = listId,
+            DueDate = task.DueDateTime?.ToDateTime()
         };
     }
 }


### PR DESCRIPTION
Add `--due-date` option to the CLI and propagate it through the handler to TodoItem.DueDate. Implement parsing (yyyy-MM-dd or MM-dd with current year) and validation in the Add command handler, showing an error for invalid formats. Persist DueDate when creating Graph tasks (maps to DueDateTime) and include the due date in TodoItem.ToString(). Update dependency injection mapping and tests to accommodate the new handler parameter.